### PR TITLE
adds order model

### DIFF
--- a/server/db/models/category.js
+++ b/server/db/models/category.js
@@ -1,2 +1,11 @@
 const Sequelize = require('sequelize')
 const db = require('../db')
+
+const Category = db.define('category', {
+  name: {
+    type: Sequelize.STRING,
+    allowNull: false
+  }
+})
+
+module.exports = Category

--- a/server/db/models/order.js
+++ b/server/db/models/order.js
@@ -1,16 +1,22 @@
 const Sequelize = require('sequelize')
 const db = require('../db')
+const Product = require('./product')
 
 const Order = db.define('order', {
-  products: Sequelize.ARRAY,
-  subtotal: Sequelize.INTEGER
+  status: {
+    type: Sequelize.ENUM('created', 'processing', 'cancelled', 'completed'),
+    defaultValue: 'approved'
+  },
+  subtotal: Sequelize.INTEGER,
+  quantity: {
+    type: Sequelize.INTEGER,
+    defaultValue: 0
+  }
+})
+
+Order.beforeCreate(async orderInstance => {
+  const product = await Product.findbyPk(orderInstance.productId)
+  orderInstance.subtotal = product.price * orderInstance.quantity
 })
 
 module.exports = Order
-
-//original markup for this model included dateCreated and timeCreated. These features should already
-//be available in the createdAt field at is provided in our db upon creation.
-
-//Additionally, I think that if products is an array of product objects, each one will have a price;
-//we can simply write an axios request to pull that subtotal in through a thunk creator. Therefore,
-//I'm not sure if we need a subtotal datatype in our Order model.

--- a/server/db/models/order.js
+++ b/server/db/models/order.js
@@ -1,2 +1,16 @@
 const Sequelize = require('sequelize')
 const db = require('../db')
+
+const Order = db.define('order', {
+  products: Sequelize.ARRAY,
+  subtotal: Sequelize.INTEGER
+})
+
+module.exports = Order
+
+//original markup for this model included dateCreated and timeCreated. These features should already
+//be available in the createdAt field at is provided in our db upon creation.
+
+//Additionally, I think that if products is an array of product objects, each one will have a price;
+//we can simply write an axios request to pull that subtotal in through a thunk creator. Therefore,
+//I'm not sure if we need a subtotal datatype in our Order model.

--- a/server/db/models/orderDetails.js
+++ b/server/db/models/orderDetails.js
@@ -1,0 +1,11 @@
+const Sequelize = require('sequelize')
+const db = require('../db')
+
+const OrderDetails = db.define('orderDetails', {
+  quantity: {
+    type: Sequelize.INTEGER,
+    defaultValue: 1
+  }
+})
+
+module.exports = OrderDetails


### PR DESCRIPTION
--would like to go over tomorrow/NOT READY to merge to master; please see below:
### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

_Your PR Notes Here_
Original markup for this model included dateCreated and timeCreated. These features should already be available in the createdAt field at is provided in our db upon creation (it includes both the time and date).

Additionally, I think that if products is an array of product objects and each one will have a price, we can simply write an axios request to pull that subtotal in through a thunk creator to the store. Therefore, I'm not sure if we need a subtotal datatype in our Order model.